### PR TITLE
Remove unneeded dependencies

### DIFF
--- a/common/src/main/java/com/microsoft/alm/helpers/IOHelper.java
+++ b/common/src/main/java/com/microsoft/alm/helpers/IOHelper.java
@@ -10,8 +10,12 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.OutputStream;
 
 public class IOHelper {
+
+    static final int BUFFER_SIZE = 4096;
+
     public static void closeQuietly(final Closeable closeable) {
         if (closeable != null) {
             try {
@@ -49,5 +53,14 @@ public class IOHelper {
             IOHelper.closeQuietly(reader);
             IOHelper.closeQuietly(isr);
         }
+    }
+
+    public static void copyStream(final InputStream is, final OutputStream os) throws IOException {
+        final byte[] buffer = new byte[BUFFER_SIZE];
+        int bytesRead;
+        while ((bytesRead = is.read(buffer, 0, BUFFER_SIZE)) != -1) {
+            os.write(buffer, 0, bytesRead);
+        }
+        os.flush();
     }
 }

--- a/common/src/test/java/com/microsoft/alm/helpers/IOHelperTest.java
+++ b/common/src/test/java/com/microsoft/alm/helpers/IOHelperTest.java
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root.
+
+package com.microsoft.alm.helpers;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * A class to test {@link IOHelper}.
+ */
+public class IOHelperTest {
+
+}

--- a/common/src/test/java/com/microsoft/alm/helpers/IOHelperTest.java
+++ b/common/src/test/java/com/microsoft/alm/helpers/IOHelperTest.java
@@ -4,11 +4,70 @@
 package com.microsoft.alm.helpers;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Random;
 
 /**
  * A class to test {@link IOHelper}.
  */
 public class IOHelperTest {
 
+    private static byte[] createRandomByteArray(final int numberOfBytes) {
+        final Random random = new Random(42);
+        final byte[] result = new byte[numberOfBytes];
+        random.nextBytes(result);
+        return result;
+    }
+
+    private static void testCopyStream(final int numberOfBytes) throws IOException {
+        final byte[] input = createRandomByteArray(numberOfBytes);
+        final ByteArrayInputStream bais = new ByteArrayInputStream(input);
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream(numberOfBytes);
+
+        IOHelper.copyStream(bais, baos);
+
+        final byte[] actual = baos.toByteArray();
+        Assert.assertArrayEquals(input, actual);
+        Assert.assertEquals(numberOfBytes, baos.size());
+    }
+
+    @Test
+    public void copyStream_zeroBuffer() throws Exception {
+        testCopyStream(0);
+    }
+
+    @Test
+    public void copyStream_oneByte() throws Exception {
+        testCopyStream(1);
+    }
+
+    @Test
+    public void copyStream_halfSmallerThanBuffer() throws Exception {
+        testCopyStream(IOHelper.BUFFER_SIZE / 2);
+    }
+
+    @Test
+    public void copyStream_justSmallerThanBuffer() throws Exception {
+        testCopyStream(IOHelper.BUFFER_SIZE - 1);
+    }
+
+    @Test
+    public void copyStream_sameAsBuffer() throws Exception {
+        testCopyStream(IOHelper.BUFFER_SIZE);
+    }
+
+    @Test
+    public void copyStream_oneMoreThanBuffer() throws Exception {
+        testCopyStream(IOHelper.BUFFER_SIZE + 1);
+    }
+
+    @Test
+    public void copyStream_twiceMoreThanBuffer() throws Exception {
+        testCopyStream(IOHelper.BUFFER_SIZE * 2);
+    }
 }

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -118,11 +118,6 @@ Licensed under the MIT license. See License.txt in the project root. -->
       <artifactId>guava</artifactId>
       <version>18.0</version>
     </dependency>
-    <dependency>
-      <groupId>com.google.code.gson</groupId>
-      <artifactId>gson</artifactId>
-      <version>2.3.1</version>
-    </dependency>
 
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -114,12 +114,6 @@ Licensed under the MIT license. See License.txt in the project root. -->
     </dependency>
 
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>18.0</version>
-    </dependency>
-
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/core/src/main/java/com/microsoft/alm/auth/oauth/helper/SwtJarLoader.java
+++ b/core/src/main/java/com/microsoft/alm/auth/oauth/helper/SwtJarLoader.java
@@ -3,7 +3,6 @@
 
 package com.microsoft.alm.auth.oauth.helper;
 
-import com.google.common.io.ByteStreams;
 import com.microsoft.alm.helpers.IOHelper;
 import com.microsoft.alm.oauth2.useragent.Provider;
 import com.microsoft.alm.oauth2.useragent.StandardWidgetToolkitProvider;
@@ -91,7 +90,7 @@ public class SwtJarLoader {
             final FileOutputStream fos = new FileOutputStream(targetSwtJar);
             final InputStream is = cloudSwtUrlConn.getInputStream();
 
-            ByteStreams.copy(is, fos);
+            IOHelper.copyStream(is, fos);
 
             IOHelper.closeQuietly(is);
             IOHelper.closeQuietly(fos);


### PR DESCRIPTION
## Manual testing

Temporarily added the following test just before e704ed4 was performed and then ran it again after the change.  The resulting file created in `$HOME/.swt/` the second time was identical to the first one.

``` java
@Test
public void tryGetSwtJar() throws Exception {
    final AtomicReference<File> swtJarReference = new AtomicReference<File>();

    final boolean actual = SwtJarLoader.tryGetSwtJar(swtJarReference);

    Assert.assertEquals(true, actual);
    final File actualFile = swtJarReference.get();
    Assert.assertNotNull(actualFile);
    Assert.assertTrue(actualFile.isFile());
}
```

Mission accomplished!
