### PR TITLE
Expose flow control logic in the response object

### DIFF
--- a/core/src/main/java/com/microsoft/alm/auth/oauth/DeviceFlowImpl.java
+++ b/core/src/main/java/com/microsoft/alm/auth/oauth/DeviceFlowImpl.java
@@ -85,6 +85,10 @@ public class DeviceFlowImpl implements DeviceFlow {
         String responseText = null;
         final Calendar expiresAt = deviceFlowResponse.getExpiresAt();
         while (Calendar.getInstance().compareTo(expiresAt) <= 0) {
+            if (deviceFlowResponse.cancelRequestedByUser()) {
+                throw new AuthorizationException("request_cancelled", "Stop polling for Token.", null, null);
+            }
+
             try {
                 final HttpURLConnection response = client.post(tokenEndpoint, requestBody);
                 final int httpStatus = response.getResponseCode();
@@ -133,6 +137,8 @@ public class DeviceFlowImpl implements DeviceFlow {
             throw new AuthorizationException("code_expired", "The verification code expired.", null, null);
         }
         final TokenPair tokenPair = buildTokenPair(responseText);
+
+        deviceFlowResponse.setTokenAcquired();
         return tokenPair;
     }
 


### PR DESCRIPTION
The DeviceFlowResponse object is passed back to the callback and is
used as a message channel between the consumer and this library. This
remove threading requirement from the library and the consumer will be
repsonsible for proper threading.

The logic is added to DeviceFlowResponse class to maintain backward
compatibility.
