### PR TITLE
Add validation logic

### DIFF
--- a/common/src/main/java/com/microsoft/alm/secret/Token.java
+++ b/common/src/main/java/com/microsoft/alm/secret/Token.java
@@ -16,6 +16,7 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.w3c.dom.Text;
 
+import javax.xml.bind.DatatypeConverter;
 import java.nio.ByteBuffer;
 import java.util.EnumSet;
 import java.util.Map;
@@ -197,6 +198,11 @@ public class Token extends Secret {
             case Access:
                 final String prefix = "Bearer";
                 headers.put("Authorization", prefix + " " + Value);
+                break;
+            case Personal:
+                final byte[] authData = StringHelper.UTF8GetBytes("PersonalAccessToken:" + Value);
+                final String base64EncodedAuthData = DatatypeConverter.printBase64Binary(authData);
+                headers.put("Authorization", "Basic " + base64EncodedAuthData);
                 break;
             case Federated:
                 throw new NotImplementedException(449222);

--- a/core/src/main/java/com/microsoft/alm/auth/BaseAuthenticator.java
+++ b/core/src/main/java/com/microsoft/alm/auth/BaseAuthenticator.java
@@ -125,7 +125,7 @@ public abstract class BaseAuthenticator implements Authenticator {
      *
      * TODO: should we also add validation behavior extension point here?
      */
-    public static abstract class SecretRetriever {
+    public static abstract class SecretRetriever<E extends Secret> {
         /**
          * Standard synchronized access to store.  Extensibility point that
          * can be overridden
@@ -134,11 +134,10 @@ public abstract class BaseAuthenticator implements Authenticator {
          *      key for that credentials are saved under
          * @param store
          *      a secret store that holds credentials
-         * @param <E> a secret type
          *
          * @return stored secret based on key, nullable
          */
-        protected <E extends Secret> E readFromStore(final String key, final SecretStore<E> store) {
+        protected E readFromStore(final String key, final SecretStore<E> store) {
             synchronized (store) {
                 return store.get(key);
             }
@@ -146,11 +145,10 @@ public abstract class BaseAuthenticator implements Authenticator {
 
         /**
          * How the secret is generated / retrieved.  This is the real work
-         * @param <E> a secret type
          *
          * @return secret
          */
-        protected abstract <E extends Secret> E doRetrieve();
+        protected abstract E doRetrieve();
 
         /**
          * Standard storing the secret based on the key
@@ -161,12 +159,11 @@ public abstract class BaseAuthenticator implements Authenticator {
          *      key for that credentials are saved under
          * @param store
          *      a secret store that holds credentials
-         * @param <E> a secret type
          *
          * @param secret
          *      secret to be saved in the store
          */
-        protected <E extends Secret> void store(final String key, final SecretStore<E> store, E secret) {
+        protected void store(final String key, final SecretStore<E> store, E secret) {
             if (secret != null) {
                 logger.debug("Storing secret for key: {}.", key);
                 synchronized (store) {
@@ -187,12 +184,11 @@ public abstract class BaseAuthenticator implements Authenticator {
          *      a secret store that holds credentials
          * @param promptBehavior
          *      determines whether we should prompt or not if we don't have a credential for the specified key
-         * @param <E> a secret type
          *
          * @return secret
          *      secret to be saved in the store
          */
-        public <E extends Secret> E retrieve(final String key, final SecretStore<E> store,
+        public E retrieve(final String key, final SecretStore<E> store,
                                                 final PromptBehavior promptBehavior) {
             logger.debug("Retrieving secret with key: {}, and prompt behavior: {}.", key, promptBehavior.name());
 

--- a/core/src/main/java/com/microsoft/alm/auth/basic/BasicAuthAuthenticator.java
+++ b/core/src/main/java/com/microsoft/alm/auth/basic/BasicAuthAuthenticator.java
@@ -81,7 +81,7 @@ public class BasicAuthAuthenticator extends BaseAuthenticator {
 
         final String key = getKey(uri);
 
-        SecretRetriever secretRetriever = new SecretRetriever() {
+        final SecretRetriever<Credential> secretRetriever = new SecretRetriever<Credential>() {
             @Override
             protected Credential doRetrieve() {
                 logger.debug("Prompt user for credential for uri: {}", uri);

--- a/core/src/main/java/com/microsoft/alm/auth/oauth/OAuth2Authenticator.java
+++ b/core/src/main/java/com/microsoft/alm/auth/oauth/OAuth2Authenticator.java
@@ -154,7 +154,8 @@ public class OAuth2Authenticator extends BaseAuthenticator {
 
         final String key = getKey(APP_VSSPS_VISUALSTUDIO);
 
-        SecretRetriever secretRetriever = new SecretRetriever() {
+        final SecretRetriever<TokenPair> secretRetriever = new SecretRetriever<TokenPair>() {
+
             @Override
             protected TokenPair doRetrieve() {
                 logger.debug("Ready to launch browser flow to retrieve oauth2 token.");

--- a/core/src/main/java/com/microsoft/alm/auth/oauth/OAuthParameter.java
+++ b/core/src/main/java/com/microsoft/alm/auth/oauth/OAuthParameter.java
@@ -19,6 +19,7 @@ class OAuthParameter {
     static final String LOGIN_HINT = "login_hint";
     static final String STATE = "state";
     static final String INTERVAL = "interval";
+    static final String REFRESH_TOKEN= "refresh_token";
 
     static final String ERROR_CODE = "error";
     static final String ERROR_DESCRIPTION = "error_description";

--- a/core/src/main/java/com/microsoft/alm/auth/pat/VstsPatAuthenticator.java
+++ b/core/src/main/java/com/microsoft/alm/auth/pat/VstsPatAuthenticator.java
@@ -135,7 +135,7 @@ public class VstsPatAuthenticator extends BaseAuthenticator {
         final String key = getKey(uri);
         Debug.Assert(key != null, "Failed to convert uri to key");
 
-        SecretRetriever secretRetriever = new SecretRetriever() {
+        final SecretRetriever<Token> secretRetriever = new SecretRetriever<Token>() {
             @Override
             protected Token doRetrieve() {
                 TokenPair oauthToken = vstsOauthAuthenticator.getOAuth2TokenPair(promptBehavior.AUTO);

--- a/storage/src/main/java/com/microsoft/alm/storage/macosx/KeychainSecurityCliStore.java
+++ b/storage/src/main/java/com/microsoft/alm/storage/macosx/KeychainSecurityCliStore.java
@@ -465,7 +465,12 @@ class KeychainSecurityCliStore {
     }
 
     public void writeTokenPair(final String targetName, final TokenPair tokenPair) {
-        writeTokenKind(targetName, SecretKind.TokenPair_Access_Token, tokenPair.AccessToken);
-        writeTokenKind(targetName, SecretKind.TokenPair_Refresh_Token, tokenPair.RefreshToken);
+        if (tokenPair.AccessToken.Value != null) {
+            writeTokenKind(targetName, SecretKind.TokenPair_Access_Token, tokenPair.AccessToken);
+        }
+
+        if (tokenPair.RefreshToken.Value != null) {
+            writeTokenKind(targetName, SecretKind.TokenPair_Refresh_Token, tokenPair.RefreshToken);
+        }
     }
 }


### PR DESCRIPTION
Use the sample app as a base:
1. Use OAuth2Authenticator with a secure, persistent TokenPair store. 
2. Comment out the sign out line.
Run it once, verify we are prompted for login, and the oauth2 token is saved correctly in the storage.  
3. Run the app again to verify we aren't prompted for login. 
4. Modify the saved AccessToken by hand to make it invalid (I did this on Mac OSX). 
4. Rerun the app and verify we are prompted again, and the original tokenPair is deleted from the storage.

This appears like we are not using the refresh token.  There is some investigation that has to happen first.  We actually refreshed the token, but the renewed AccessToken is not accompanied by a refreshToken, and we don't consider that is a successful retrival.  

Repeat this process, but with a VstsPatAuthenticator with a secure, persistent Token store to verify we prompt when the PAT is invalid.
