### PR TITLE
Users/yacao/skipversionparse

### DIFF
--- a/core/src/main/java/com/microsoft/alm/auth/oauth/OAuth2Authenticator.java
+++ b/core/src/main/java/com/microsoft/alm/auth/oauth/OAuth2Authenticator.java
@@ -223,6 +223,7 @@ public class OAuth2Authenticator extends BaseAuthenticator {
 
                 final String defaultProviderName
                         = System.getProperty(USER_AGENT_PROVIDER_PROPERTY_NAME, JAVAFX_PROVIDER_NAME);
+                logger.info("Attempt to use oauth2-useragent provider: {}", defaultProviderName);
 
                 final boolean favorSwtBrowser
                         = defaultProviderName.equals(SWT_PROIVDER_NAME);
@@ -236,19 +237,21 @@ public class OAuth2Authenticator extends BaseAuthenticator {
                     }
                 }
 
-                if (!favorDeviceFlow && oAuth2UseragentValidator.isOAuth2ProviderAvailable()
-                        || (oAuth2UseragentValidator.isOnlyMissingRuntimeFromSwtProvider()
+                if (!favorDeviceFlow) {
+                    if (oAuth2UseragentValidator.isOAuth2ProviderAvailable()
+                            || (oAuth2UseragentValidator.isOnlyMissingRuntimeFromSwtProvider()
                             && SwtJarLoader.tryGetSwtJar(swtRuntime))) {
-                    try {
-                        logger.info("Using oauth2-useragent providers to retrieve AAD token.");
-                        return getAzureAuthority(uri).acquireToken(clientId, resource, redirectUri, POPUP_QUERY_PARAM);
-                    } catch (final AuthorizationException e) {
-                        logError(logger, "Failed to launch oauth2-useragent.", e);
-                        // unless we failed with unknown reasons (such as failed to load javafx) we probably should
-                        // just return null
-                        if (!"unknown_error".equalsIgnoreCase(e.getCode())) {
-                            // This error code isn't exposed as a value, so just hardcode this string
-                            return null;
+                        try {
+                            logger.info("Using oauth2-useragent providers to retrieve AAD token.");
+                            return getAzureAuthority(uri).acquireToken(clientId, resource, redirectUri, POPUP_QUERY_PARAM);
+                        } catch (final AuthorizationException e) {
+                            logError(logger, "Failed to launch oauth2-useragent.", e);
+                            // unless we failed with unknown reasons (such as failed to load javafx) we probably should
+                            // just return null
+                            if (!"unknown_error".equalsIgnoreCase(e.getCode())) {
+                                // This error code isn't exposed as a value, so just hardcode this string
+                                return null;
+                            }
                         }
                     }
                 }

--- a/core/src/main/java/com/microsoft/alm/auth/oauth/OAuth2Authenticator.java
+++ b/core/src/main/java/com/microsoft/alm/auth/oauth/OAuth2Authenticator.java
@@ -11,7 +11,6 @@ import com.microsoft.alm.helpers.Action;
 import com.microsoft.alm.helpers.Debug;
 import com.microsoft.alm.helpers.HttpClient;
 import com.microsoft.alm.oauth2.useragent.AuthorizationException;
-import com.microsoft.alm.oauth2.useragent.Provider;
 import com.microsoft.alm.secret.Token;
 import com.microsoft.alm.secret.TokenPair;
 import com.microsoft.alm.storage.InsecureInMemoryStore;
@@ -38,6 +37,9 @@ public class OAuth2Authenticator extends BaseAuthenticator {
     public final static String MANAGEMENT_CORE_RESOURCE = "https://management.core.windows.net/";
     public final static String VALIDATION_ENDPOINT = APP_VSSPS_VISUALSTUDIO + "/_apis/connectionData";
     public static final String VSTS_RESOURCE = "499b84ac-1321-427f-aa17-267ca6975798";
+
+    public static final String SWT_PROIVDER_NAME = "StandardWidgetToolkit";
+    public static final String JAVAFX_PROVIDER_NAME = "JavaFx";
 
     private final static String TYPE = "OAuth2";
 
@@ -220,10 +222,10 @@ public class OAuth2Authenticator extends BaseAuthenticator {
                 final AtomicReference<File> swtRuntime = new AtomicReference<File>();
 
                 final String defaultProviderName
-                        = System.getProperty(USER_AGENT_PROVIDER_PROPERTY_NAME, Provider.JAVA_FX.getClassName());
+                        = System.getProperty(USER_AGENT_PROVIDER_PROPERTY_NAME, JAVAFX_PROVIDER_NAME);
 
                 final boolean favorSwtBrowser
-                        = defaultProviderName.equals(Provider.STANDARD_WIDGET_TOOLKIT.getClassName());
+                        = defaultProviderName.equals(SWT_PROIVDER_NAME);
 
                 final boolean favorDeviceFlow = defaultProviderName.equalsIgnoreCase("none");
 

--- a/core/src/main/java/com/microsoft/alm/auth/pat/VstsPatAuthenticator.java
+++ b/core/src/main/java/com/microsoft/alm/auth/pat/VstsPatAuthenticator.java
@@ -159,7 +159,7 @@ public class VstsPatAuthenticator extends BaseAuthenticator {
                 Debug.Assert(token != null, "Token is null");
                 Debug.Assert(holder != null, "Holder is null");
 
-                final URI validationEndpoint = URI.create(OAuth2Authenticator.VALIDATION_ENDPOINT);
+                final URI validationEndpoint = URI.create(uri + "/_apis/connectionData");
                 boolean valid = false;
 
                 if (token.Value != null) {


### PR DESCRIPTION
1. Fix device flow precedence check - we shouldn't check for swt if we favor device flow.
2. Catch the JRE version parsing error -- this is an expected error in parsing IBM jre.  