### PR TITLE
Build with Java 8 instead of Java 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ script:
 # https://docs.travis-ci.com/user/migrating-from-legacy/
 sudo: false
 jdk:
-  - openjdk6
+  - oraclejdk8


### PR DESCRIPTION
openjdk6 is not available on Travis CI.