### PR TITLE
Pluggable user agent support

### DIFF
--- a/core/src/main/java/com/microsoft/alm/auth/oauth/AzureAuthority.java
+++ b/core/src/main/java/com/microsoft/alm/auth/oauth/AzureAuthority.java
@@ -69,7 +69,11 @@ public class AzureAuthority {
      * @param authorityHostUrl Non-default authority host url.
      */
     public AzureAuthority(final String authorityHostUrl) {
-        this(authorityHostUrl, new UserAgentImpl(), new AzureDeviceFlow());
+        this(authorityHostUrl, new UserAgentImpl());
+    }
+
+    public AzureAuthority(final String authorityHostUrl, final UserAgent userAgent) {
+        this(authorityHostUrl, userAgent, new AzureDeviceFlow());
     }
 
     AzureAuthority(final String authorityHostUrl, final UserAgent userAgent, final AzureDeviceFlow azureDeviceFlow) {

--- a/core/src/main/java/com/microsoft/alm/auth/oauth/helper/AzureAuthorityProvider.java
+++ b/core/src/main/java/com/microsoft/alm/auth/oauth/helper/AzureAuthorityProvider.java
@@ -18,9 +18,17 @@ import java.util.UUID;
 public class AzureAuthorityProvider {
     private static final Logger logger = LoggerFactory.getLogger(AzureAuthorityProvider.class);
 
+    protected AzureAuthority getDefaultAzureAuthority() {
+        return AzureAuthority.DefaultAzureAuthority;
+    }
+
+    protected AzureAuthority getAzureAuthorityForHostUrl(String hostUrl) {
+        return new AzureAuthority(hostUrl);
+    }
+
     public AzureAuthority getAzureAuthority(final URI uri) throws IOException {
         if (uri == OAuth2Authenticator.APP_VSSPS_VISUALSTUDIO) {
-            return AzureAuthority.DefaultAzureAuthority;
+            return getDefaultAzureAuthority();
         }
 
         logger.debug("Lookup tenant id for {}", uri);
@@ -28,10 +36,10 @@ public class AzureAuthorityProvider {
         logger.debug("tenant id for {} is {}", uri, tenantId);
         if (tenantId == null) {
             // backed by MSA account
-            return AzureAuthority.DefaultAzureAuthority;
+            return getDefaultAzureAuthority();
         }
 
-        return new AzureAuthority(AzureAuthority.AuthorityHostUrlBase + "/" + tenantId);
+        return getAzureAuthorityForHostUrl(AzureAuthority.AuthorityHostUrlBase + "/" + tenantId);
     }
 
 }

--- a/core/src/test/java/com/microsoft/alm/auth/oauth/OAuth2AuthenticatorTest.java
+++ b/core/src/test/java/com/microsoft/alm/auth/oauth/OAuth2AuthenticatorTest.java
@@ -64,7 +64,8 @@ public class OAuth2AuthenticatorTest {
                 TEST_REDIRECT_URI,
                 mockStore,
                 mockOAuth2UseragentValidator,
-                testCallback);
+                testCallback,
+                new AzureAuthorityProvider());
 
         underTest.setAzureAuthorityProvider(mockAzureAuthorityProvider);
     }
@@ -119,7 +120,8 @@ public class OAuth2AuthenticatorTest {
                 TEST_REDIRECT_URI,
                 mockStore,
                 mockOAuth2UseragentValidator,
-                null /* no callback specified */);
+                null, /* no callback specified */
+                new AzureAuthorityProvider());
 
         final TokenPair token = underTest.getOAuth2TokenPair();
 


### PR DESCRIPTION
This will allow the library users to provide their own implementations of `AzureAuthorityProvider` and `OAuth2UseragentValidator`, and to create `AzureAuthority` with custom `UserAgent` if necessary (e.g. when implementing their own user agent providers).

It is critical for the DPI issue in the Azure DevOps plugin, see https://github.com/microsoft/azure-devops-intellij/issues/237 and https://github.com/microsoft/azure-devops-intellij/pull/238 for details (the latter PR shows a sample usage of the new API from this PR).